### PR TITLE
Added support for multi-process debugging

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,10 +40,37 @@ module.exports = function(app, options) {
       logger.error(('worker ' + worker.process.pid + ' died').red + ', reforking...')
       var worker = cluster.fork()
     })
+    
+    debug_mode = false;
+    debug_brk = false;
+    
+    // Determine if the master process was launched with --debug or --debug-brk
+    process.execArgv.forEach(function(arg) {
+      if (arg == '--debug' || arg.indexOf('--debug=') > -1) {
+        debug_mode = true;
+      } else if (arg == '--debug-brk') {
+        debug_brk = true;
+      }
+    });
+    
+    // Init the cluster execArgv array
+    cluster.setupMaster({
+      execArgv: process.execArgv.filter(function(s) { return s.indexOf('--debug') == -1 })
+    });
 
     // Fork workers.
     for (var i = 0; i < workers; i++) {
-      cluster.fork()
+      // Append requested debug flags to cluster settings so new forks have the flags
+      // Give each forked process a new debug port
+      if (debug_mode) { cluster.settings.execArgv.push('--debug=' + (5859 + i)); }
+      if (debug_brk) { cluster.settings.execArgv.push('--debug-brk'); }
+      
+      cluster.fork();
+      
+      // Remove the flags so additional are not set with debugging
+      if (debug_mode || debug_brk) {
+        cluster.settings.execArgv = cluster.settings.execArgv.filter(function(s) { return s.indexOf('--debug') == -1 });
+      }
     }
 
   } else {

--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@ module.exports = function(app, options) {
   var logger  = (options && options.logger) || app.get('logger') || console
     , port    = (options && options.port) || app.get('port')
     , sock    = (options && options.sock) || app.get('sock')
+    , debug_port = 5859
     , workers
 
   if (options && typeof options.workers === 'number') {
@@ -62,7 +63,7 @@ module.exports = function(app, options) {
     for (var i = 0; i < workers; i++) {
       // Append requested debug flags to cluster settings so new forks have the flags
       // Give each forked process a new debug port
-      if (debug_mode) { cluster.settings.execArgv.push('--debug=' + (5859 + i)); }
+      if (debug_mode) { cluster.settings.execArgv.push('--debug=' + (debug_port + i)); }
       if (debug_brk) { cluster.settings.execArgv.push('--debug-brk'); }
       
       cluster.fork();


### PR DESCRIPTION
Added code that determines whether the master process was instantiated with --debug, and if so, passes the flag down to the forked processes and gives each fork a unique debug port.
